### PR TITLE
#30 Make draft data live in asset overview

### DIFF
--- a/api/sk-serve/graph/generated/generated.go
+++ b/api/sk-serve/graph/generated/generated.go
@@ -94,6 +94,16 @@ type ComplexityRoot struct {
 		LeadingWins  func(childComplexity int) int
 	}
 
+	DraftPick struct {
+		Round func(childComplexity int) int
+		Value func(childComplexity int) int
+	}
+
+	DraftYear struct {
+		Picks func(childComplexity int) int
+		Year  func(childComplexity int) int
+	}
+
 	League struct {
 		Divisions  func(childComplexity int) int
 		ID         func(childComplexity int) int
@@ -133,10 +143,16 @@ type ComplexityRoot struct {
 
 	Team struct {
 		CurrentContractsMetadata func(childComplexity int) int
+		Division                 func(childComplexity int) int
 		FoundedDate              func(childComplexity int) int
 		ID                       func(childComplexity int) int
 		OwnerID                  func(childComplexity int) int
+		TeamAssets               func(childComplexity int) int
 		TeamName                 func(childComplexity int) int
+	}
+
+	TeamAssets struct {
+		DraftPicks func(childComplexity int) int
 	}
 
 	User struct {
@@ -411,6 +427,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Division.LeadingWins(childComplexity), true
 
+	case "DraftPick.round":
+		if e.complexity.DraftPick.Round == nil {
+			break
+		}
+
+		return e.complexity.DraftPick.Round(childComplexity), true
+
+	case "DraftPick.value":
+		if e.complexity.DraftPick.Value == nil {
+			break
+		}
+
+		return e.complexity.DraftPick.Value(childComplexity), true
+
+	case "DraftYear.picks":
+		if e.complexity.DraftYear.Picks == nil {
+			break
+		}
+
+		return e.complexity.DraftYear.Picks(childComplexity), true
+
+	case "DraftYear.year":
+		if e.complexity.DraftYear.Year == nil {
+			break
+		}
+
+		return e.complexity.DraftYear.Year(childComplexity), true
+
 	case "League.divisions":
 		if e.complexity.League.Divisions == nil {
 			break
@@ -648,6 +692,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Team.CurrentContractsMetadata(childComplexity), true
 
+	case "Team.division":
+		if e.complexity.Team.Division == nil {
+			break
+		}
+
+		return e.complexity.Team.Division(childComplexity), true
+
 	case "Team.foundedDate":
 		if e.complexity.Team.FoundedDate == nil {
 			break
@@ -669,12 +720,26 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Team.OwnerID(childComplexity), true
 
+	case "Team.teamAssets":
+		if e.complexity.Team.TeamAssets == nil {
+			break
+		}
+
+		return e.complexity.Team.TeamAssets(childComplexity), true
+
 	case "Team.teamName":
 		if e.complexity.Team.TeamName == nil {
 			break
 		}
 
 		return e.complexity.Team.TeamName(childComplexity), true
+
+	case "TeamAssets.draftPicks":
+		if e.complexity.TeamAssets.DraftPicks == nil {
+			break
+		}
+
+		return e.complexity.TeamAssets.DraftPicks(childComplexity), true
 
 	case "User.avatar":
 		if e.complexity.User.Avatar == nil {
@@ -852,12 +917,15 @@ type Team {
     foundedDate: Time!
     teamName: String!
     ownerID: String!
+    division: String
     currentContractsMetadata: ContractsMetadata
+    teamAssets: TeamAssets
 }
 
 input NewTeam {
     id: ID!
     teamName: String!
+    division: String
     foundedDate: Time
 }
 
@@ -869,6 +937,21 @@ type ContractsMetadata {
     wrUtilizedCap: CapUtilizationSummary!
     teUtilizedCap: CapUtilizationSummary!
 }
+
+type TeamAssets {
+    draftPicks: [DraftYear]!
+}
+
+type DraftYear {
+    year: Int!
+    picks: [DraftPick]!
+}
+
+type DraftPick {
+    round: Int!
+    value: Int
+}
+
 
 type CapUtilizationSummary {
     capUtilization: Int!
@@ -2329,6 +2412,143 @@ func (ec *executionContext) _Division_leadingWins(ctx context.Context, field gra
 	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _DraftPick_round(ctx context.Context, field graphql.CollectedField, obj *model.DraftPick) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "DraftPick",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Round, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _DraftPick_value(ctx context.Context, field graphql.CollectedField, obj *model.DraftPick) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "DraftPick",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*int)
+	fc.Result = res
+	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _DraftYear_year(ctx context.Context, field graphql.CollectedField, obj *model.DraftYear) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "DraftYear",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Year, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _DraftYear_picks(ctx context.Context, field graphql.CollectedField, obj *model.DraftYear) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "DraftYear",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Picks, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.DraftPick)
+	fc.Result = res
+	return ec.marshalNDraftPick2ᚕᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐDraftPick(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _League_id(ctx context.Context, field graphql.CollectedField, obj *model.League) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -3462,6 +3682,38 @@ func (ec *executionContext) _Team_ownerID(ctx context.Context, field graphql.Col
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Team_division(ctx context.Context, field graphql.CollectedField, obj *model.Team) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Team",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Division, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Team_currentContractsMetadata(ctx context.Context, field graphql.CollectedField, obj *model.Team) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -3492,6 +3744,73 @@ func (ec *executionContext) _Team_currentContractsMetadata(ctx context.Context, 
 	res := resTmp.(*model.ContractsMetadata)
 	fc.Result = res
 	return ec.marshalOContractsMetadata2ᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐContractsMetadata(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Team_teamAssets(ctx context.Context, field graphql.CollectedField, obj *model.Team) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Team",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TeamAssets, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*model.TeamAssets)
+	fc.Result = res
+	return ec.marshalOTeamAssets2ᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐTeamAssets(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _TeamAssets_draftPicks(ctx context.Context, field graphql.CollectedField, obj *model.TeamAssets) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "TeamAssets",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DraftPicks, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*model.DraftYear)
+	fc.Result = res
+	return ec.marshalNDraftYear2ᚕᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐDraftYear(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _User_id(ctx context.Context, field graphql.CollectedField, obj *model.User) (ret graphql.Marshaler) {
@@ -5008,6 +5327,14 @@ func (ec *executionContext) unmarshalInputNewTeam(ctx context.Context, obj inter
 			if err != nil {
 				return it, err
 			}
+		case "division":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("division"))
+			it.Division, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "foundedDate":
 			var err error
 
@@ -5352,6 +5679,67 @@ func (ec *executionContext) _Division(ctx context.Context, sel ast.SelectionSet,
 	return out
 }
 
+var draftPickImplementors = []string{"DraftPick"}
+
+func (ec *executionContext) _DraftPick(ctx context.Context, sel ast.SelectionSet, obj *model.DraftPick) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, draftPickImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DraftPick")
+		case "round":
+			out.Values[i] = ec._DraftPick_round(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "value":
+			out.Values[i] = ec._DraftPick_value(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var draftYearImplementors = []string{"DraftYear"}
+
+func (ec *executionContext) _DraftYear(ctx context.Context, sel ast.SelectionSet, obj *model.DraftYear) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, draftYearImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DraftYear")
+		case "year":
+			out.Values[i] = ec._DraftYear_year(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "picks":
+			out.Values[i] = ec._DraftYear_picks(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var leagueImplementors = []string{"League"}
 
 func (ec *executionContext) _League(ctx context.Context, sel ast.SelectionSet, obj *model.League) graphql.Marshaler {
@@ -5659,8 +6047,39 @@ func (ec *executionContext) _Team(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "division":
+			out.Values[i] = ec._Team_division(ctx, field, obj)
 		case "currentContractsMetadata":
 			out.Values[i] = ec._Team_currentContractsMetadata(ctx, field, obj)
+		case "teamAssets":
+			out.Values[i] = ec._Team_teamAssets(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var teamAssetsImplementors = []string{"TeamAssets"}
+
+func (ec *executionContext) _TeamAssets(ctx context.Context, sel ast.SelectionSet, obj *model.TeamAssets) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, teamAssetsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TeamAssets")
+		case "draftPicks":
+			out.Values[i] = ec._TeamAssets_draftPicks(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -6128,6 +6547,80 @@ func (ec *executionContext) marshalNDivision2ᚖgithubᚗcomᚋrifaulknerᚋspor
 		return graphql.Null
 	}
 	return ec._Division(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNDraftPick2ᚕᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐDraftPick(ctx context.Context, sel ast.SelectionSet, v []*model.DraftPick) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalODraftPick2ᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐDraftPick(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalNDraftYear2ᚕᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐDraftYear(ctx context.Context, sel ast.SelectionSet, v []*model.DraftYear) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalODraftYear2ᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐDraftYear(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
 }
 
 func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v interface{}) (float64, error) {
@@ -6652,6 +7145,20 @@ func (ec *executionContext) marshalODivision2ᚕᚖgithubᚗcomᚋrifaulknerᚋs
 	return ret
 }
 
+func (ec *executionContext) marshalODraftPick2ᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐDraftPick(ctx context.Context, sel ast.SelectionSet, v *model.DraftPick) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._DraftPick(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalODraftYear2ᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐDraftYear(ctx context.Context, sel ast.SelectionSet, v *model.DraftYear) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._DraftYear(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOFloat2ᚖfloat64(ctx context.Context, v interface{}) (*float64, error) {
 	if v == nil {
 		return nil, nil
@@ -6853,6 +7360,13 @@ func (ec *executionContext) marshalOTeam2ᚖgithubᚗcomᚋrifaulknerᚋsports�
 		return graphql.Null
 	}
 	return ec._Team(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOTeamAssets2ᚖgithubᚗcomᚋrifaulknerᚋsportsᚑkernelᚋapiᚋskᚑserveᚋgraphᚋmodelᚐTeamAssets(ctx context.Context, sel ast.SelectionSet, v *model.TeamAssets) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TeamAssets(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {

--- a/api/sk-serve/graph/model/models_gen.go
+++ b/api/sk-serve/graph/model/models_gen.go
@@ -78,6 +78,16 @@ type Division struct {
 	LeadingWins  *int   `json:"leadingWins"`
 }
 
+type DraftPick struct {
+	Round int  `json:"round"`
+	Value *int `json:"value"`
+}
+
+type DraftYear struct {
+	Year  int          `json:"year"`
+	Picks []*DraftPick `json:"picks"`
+}
+
 type League struct {
 	ID         string      `json:"id"`
 	LeagueName string      `json:"leagueName"`
@@ -90,6 +100,7 @@ type League struct {
 type NewTeam struct {
 	ID          string     `json:"id"`
 	TeamName    string     `json:"teamName"`
+	Division    *string    `json:"division"`
 	FoundedDate *time.Time `json:"foundedDate"`
 }
 
@@ -113,7 +124,13 @@ type Team struct {
 	FoundedDate              time.Time          `json:"foundedDate"`
 	TeamName                 string             `json:"teamName"`
 	OwnerID                  string             `json:"ownerID"`
+	Division                 *string            `json:"division"`
 	CurrentContractsMetadata *ContractsMetadata `json:"currentContractsMetadata"`
+	TeamAssets               *TeamAssets        `json:"teamAssets"`
+}
+
+type TeamAssets struct {
+	DraftPicks []*DraftYear `json:"draftPicks"`
 }
 
 type User struct {

--- a/api/sk-serve/graph/schema.resolvers.go
+++ b/api/sk-serve/graph/schema.resolvers.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/rifaulkner/sports-kernel/api/sk-serve/graph/generated"
@@ -30,39 +29,12 @@ func (r *mutationResolver) CreateUser(ctx context.Context, input model.NewUser) 
 }
 
 func (r *mutationResolver) CreateTeam(ctx context.Context, leagueID *string, input model.NewTeam) (*model.Team, error) {
-	currentContractsMetadataDefault := model.ContractsMetadata{
-		TotalUtilizedCap:  0,
-		TotalAvailableCap: 200000000,
-		QbUtilizedCap: &model.CapUtilizationSummary{
-			CapUtilization: 0,
-			NumContracts:   0,
-		},
-		RbUtilizedCap: &model.CapUtilizationSummary{
-			CapUtilization: 0,
-			NumContracts:   0,
-		},
-		WrUtilizedCap: &model.CapUtilizationSummary{
-			CapUtilization: 0,
-			NumContracts:   0,
-		},
-		TeUtilizedCap: &model.CapUtilizationSummary{
-			CapUtilization: 0,
-			NumContracts:   0,
-		},
-	}
-	team := model.Team{
-		ID:                       input.ID,
-		TeamName:                 input.TeamName,
-		FoundedDate:              time.Now(),
-		CurrentContractsMetadata: &currentContractsMetadataDefault,
-	}
-
-	err := r.TeamResolver.Create(ctx, *leagueID, team)
+	team, err := r.TeamResolver.Create(ctx, *leagueID, input)
 	if err != nil {
 		return nil, err
 	}
 
-	return &team, nil
+	return team, nil
 }
 
 func (r *mutationResolver) UpdateTeamMetaData(ctx context.Context, leagueID string, teamID string) (*model.Team, error) {
@@ -137,8 +109,8 @@ func (r *queryResolver) Teams(ctx context.Context, leagueID *string) ([]*model.T
 	return teams, nil
 }
 
-func (r *queryResolver) TeamByID(ctx context.Context, leagueId string, teamId string) (*model.Team, error) {
-	team, err := r.TeamResolver.GetTeamById(ctx, leagueId, teamId)
+func (r *queryResolver) TeamByID(ctx context.Context, leagueID string, teamID string) (*model.Team, error) {
+	team, err := r.TeamResolver.GetTeamById(ctx, leagueID, teamID)
 	if err != nil {
 		return nil, err
 	}

--- a/api/sk-serve/graph/schema/team/team.graphqls
+++ b/api/sk-serve/graph/schema/team/team.graphqls
@@ -4,12 +4,15 @@ type Team {
     foundedDate: Time!
     teamName: String!
     ownerID: String!
+    division: String
     currentContractsMetadata: ContractsMetadata
+    teamAssets: TeamAssets
 }
 
 input NewTeam {
     id: ID!
     teamName: String!
+    division: String
     foundedDate: Time
 }
 
@@ -21,6 +24,21 @@ type ContractsMetadata {
     wrUtilizedCap: CapUtilizationSummary!
     teUtilizedCap: CapUtilizationSummary!
 }
+
+type TeamAssets {
+    draftPicks: [DraftYear]!
+}
+
+type DraftYear {
+    year: Int!
+    picks: [DraftPick]!
+}
+
+type DraftPick {
+    round: Int!
+    value: Int
+}
+
 
 type CapUtilizationSummary {
     capUtilization: Int!

--- a/api/sk-serve/team/team_service.go
+++ b/api/sk-serve/team/team_service.go
@@ -10,6 +10,6 @@ type Team interface {
 	//Change this to a path reference to the league or whatever object we're looking for
 	GetAll(ctx context.Context, leagueId string) ([]*model.Team, error)
 	GetTeamById(ctx context.Context, leagueId string, teamId string) (*model.Team, error)
-	Create(ctx context.Context, leagueId string, team model.Team) error
+	Create(ctx context.Context, leagueId string, team model.NewTeam) (*model.Team, error)
 	UpdateTeamContractMetaData(ctx context.Context, leagueId string, teamContracts []*model.Contract) error
 }

--- a/app/components/league/ContractsOverview.vue
+++ b/app/components/league/ContractsOverview.vue
@@ -100,10 +100,10 @@ export default {
   },
   methods: {
     getColor(capRemaining) {
-      if (capRemaining < 5) {
+      if (capRemaining < 5000000) {
         return 'error';
       }
-      if (capRemaining < 10) {
+      if (capRemaining < 10000000) {
         return 'warning'
       }
       return 'success';

--- a/app/components/league/TeamAssetsBreakdown.vue
+++ b/app/components/league/TeamAssetsBreakdown.vue
@@ -19,7 +19,7 @@
       <v-row>
         <v-data-table
             :headers="assets.draftPicksHeaders"
-            :items="draftPicks"
+            :items="processedDraftPicks"
             item-key="title"
             hide-default-footer
         >
@@ -53,7 +53,7 @@
 <script>
 import DraftBreakDownList from "~/components/league/DraftBreakDownList";
 import TeamContractsBreakdown from "~/components/league/TeamContractsBreakdown";
-import {TEAM_CONTRACTS} from "~/graphql/queries/team/teamGraphQL";
+import {TEAM_CONTRACTS, TEAM_DRAFT_PICKS} from "~/graphql/queries/team/teamGraphQL";
 export default {
   name: "TeamAssetsBreakdown",
   components: {TeamContractsBreakdown, DraftBreakDownList},
@@ -71,51 +71,7 @@ export default {
     return {
       contracts: [],
       teamAssets: {
-        draftPicks: [
-          {
-            year: 2022,
-            picks: [
-              {round:1, pickValue: 1},
-              {round:1, pickValue: 15},
-              {round:2, pickValue: 33},
-              {round:3, pickValue: 65},
-            ]
-          },
-          {
-            year: 2023,
-            picks: [
-              {round:1, pickValue: 1},
-              {round:2, pickValue: 33},
-              {round:3, pickValue: 65},
-            ]
-          },
-          {
-            year: 2024,
-            picks: [
-              {round:1, pickValue: null},
-              {round:2, pickValue: null},
-              {round:3, pickValue: null},
-            ]
-          },
-          {
-            year: 2025,
-            picks: [
-              {round:1, pickValue: null},
-              {round:2, pickValue: null},
-              {round:3, pickValue: null},
-              {round:4, pickValue: null},
-            ]
-          },
-          {
-            year: 2026,
-            picks: [
-              {round:1, pickValue: null},
-              {round:2, pickValue: null},
-              {round:3, pickValue: null},
-              {round:4, pickValue: null},
-            ]
-          }
-        ]
+        draftPicks: []
       },
       assets: {
         draftPicksTitle: "Draft Picks",
@@ -135,10 +91,14 @@ export default {
     }
   },
   computed: {
-    draftPicks: function() {
+    processedDraftPicks: function() {
+      if (this.teamAssets === null || this.teamAssets.draftPicks === null) {
+        return [];
+      }
+
       let tableObject = [];
 
-      for (let roundNum = 0; roundNum < 4; roundNum++) {
+      for (let roundNum = 0; roundNum < 5; roundNum++) {
         let roundDataList = [];
         const roundNumber = roundNum+1;
 
@@ -179,6 +139,16 @@ export default {
         }
       },
       update: data => data.teamContracts,
+    },
+    teamAssets: {
+      query: TEAM_DRAFT_PICKS,
+      variables() {
+        return {
+          leagueId: this.leagueId,
+          teamId: this.teamId
+        }
+      },
+      update: data => data.teamById.teamAssets,
     }
   }
 }

--- a/app/graphql/queries/team/teamGraphQL.js
+++ b/app/graphql/queries/team/teamGraphQL.js
@@ -24,3 +24,19 @@ export const TEAM_CONTRACTS = gql`
         }
     }
 `
+
+export const TEAM_DRAFT_PICKS = gql`
+    query getTeamById($leagueId:ID!, $teamId: ID!) {
+        teamById(leagueId: $leagueId, teamId:$teamId) {
+            teamAssets{
+                draftPicks{
+                    year
+                    picks{
+                        round
+                        value
+                    }
+                }
+            }
+        }
+    }
+`

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -175,6 +175,11 @@ export default {
           title: 'Strategy',
           to: '/strategy'
         },
+        {
+          icon: 'mdi-account-wrench',
+          title: 'Admin',
+          to: '/admin'
+        },
       ],
       title: 'Sports Kernel',
       userAccountActions: [

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -1,0 +1,35 @@
+<template v-slot:extension>
+  <v-tabs-items v-model="tab">
+    <v-tab-item>
+      <h1>Manage leagues</h1>
+    </v-tab-item>
+    <v-tab-item>
+      <h1>Contracts</h1>
+    </v-tab-item>
+    <v-tab-item>
+      <h1>Trades</h1>
+    </v-tab-item>
+
+  </v-tabs-items>
+</template>
+
+<script>
+export default {
+  name: "admin.vue",
+  middleware: 'auth',
+  computed: {
+    tab() {
+      return this.$store.state.application.activeTab;
+    },
+  },
+  created() {
+    this.$store.dispatch("application/updateSubmenu", [
+      'Manage Leagues', 'Contracts', 'Trades'
+    ]);
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/app/pages/draft-tools.vue
+++ b/app/pages/draft-tools.vue
@@ -11,7 +11,8 @@
 
 <script>
 export default {
-  name: "draft-tools.vue"
+  name: "draft-tools.vue",
+  middleware: 'auth',
 }
 </script>
 

--- a/app/pages/league.vue
+++ b/app/pages/league.vue
@@ -13,7 +13,7 @@
         </v-card-text>
       </v-card>
     </v-tab-item>
-    <v-tab-item >
+    <v-tab-item>
       <v-card>
         <v-card-text>
           <contracts-overview

--- a/app/schema.graphql
+++ b/app/schema.graphql
@@ -36,8 +36,8 @@ type ContractDetail {
 
 type ContractYear {
     guaranteedAmount: Float!
-    paidAmount: Float!
-    totalAmount: Float!
+    paidAmount: Int!
+    totalAmount: Int!
     year: Int!
 }
 
@@ -55,6 +55,16 @@ type Division {
     leadingWins: Int
 }
 
+type DraftPick {
+    round: Int!
+    value: Int
+}
+
+type DraftYear {
+    picks: [DraftPick]!
+    year: Int!
+}
+
 type League {
     divisions: [Division!]
     id: ID!
@@ -68,6 +78,7 @@ type Mutation {
     createContract(input: ContractInput, leagueId: ID): Contract!
     createTeam(input: NewTeam!, leagueId: ID): Team!
     createUser(input: NewUser!): User!
+    updateTeamMetaData(leagueId: ID!, teamId: ID!): Team!
 }
 
 type PlayerNFL {
@@ -84,6 +95,7 @@ type Query {
     leagues: [League]
     player(playerId: ID): PlayerNFL!
     players(numOfResults: Int): [PlayerNFL!]
+    teamById(leagueId: ID!, teamId: ID!): Team
     teamContracts(leagueId: ID, teamId: ID): [Contract!]
     teams(leagueId: ID): [Team!]
     userPreferences(userId: ID): UserPreferences
@@ -92,10 +104,16 @@ type Query {
 
 type Team {
     currentContractsMetadata: ContractsMetadata
+    division: String
     foundedDate: Time!
     id: ID!
     ownerID: String!
+    teamAssets: TeamAssets
     teamName: String!
+}
+
+type TeamAssets {
+    draftPicks: [DraftYear]!
 }
 
 type User {
@@ -123,7 +141,7 @@ input ContractInput {
     contractLength: Int
     currentYear: Int!
     playerId: String!
-    playerPosition: String
+    playerPosition: String!
     restructureStatus: ContractRestructureStatus!
     teamId: String!
     totalContractValue: Float
@@ -138,7 +156,9 @@ input ContractYearInput {
 }
 
 input NewTeam {
+    division: String
     foundedDate: Time
+    id: ID!
     teamName: String!
 }
 


### PR DESCRIPTION
Added bones for an Admin page
Created GQL for draft data
Added default draft data
Added ability to force recalculation of team contract metadata