### PR TITLE
Update player queries to be PascelCase

### DIFF
--- a/api/sk-serve/db/player_repository.go
+++ b/api/sk-serve/db/player_repository.go
@@ -39,13 +39,13 @@ func (p *PlayerRepositoryImpl) GetAll(ctx context.Context, numberOfResults *int)
 	if *numberOfResults == -1 {
 		results, err = p.Client.
 			Collection(appFirestore.PlayerCollection).
-			OrderBy("overallRank", firestore.Asc).
+			OrderBy("OverallRank", firestore.Asc).
 			Documents(ctx).
 			GetAll()
 	} else {
 		results, err = p.Client.
 			Collection(appFirestore.PlayerCollection).
-			OrderBy("overallRank", firestore.Asc).
+			OrderBy("OverallRank", firestore.Asc).
 			Limit(*numberOfResults).
 			Documents(ctx).
 			GetAll()
@@ -62,7 +62,7 @@ func (p *PlayerRepositoryImpl) GetAll(ctx context.Context, numberOfResults *int)
 func (p *PlayerRepositoryImpl) GetPlayersByPosition(ctx context.Context, position model.PlayerPosition) ([]*model.PlayerNfl, bool) {
 	results, err := p.Client.
 		Collection(appFirestore.PlayerCollection).
-		Where("position", "==", position).
+		Where("Position", "==", position).
 		Documents(ctx).
 		GetAll()
 

--- a/api/sk-serve/gqlgen.yml
+++ b/api/sk-serve/gqlgen.yml
@@ -60,7 +60,7 @@ models:
       - github.com/rifaulkner/sports-kernel/api/sk-serve/contract.Contract
     fields:
       Player:
-        resolver: true
+        resolver: true––
   ContractInput:
     model:
       - github.com/rifaulkner/sports-kernel/api/sk-serve/contract.ContractInput


### PR DESCRIPTION
Adding in fixes to player queries to account for the updated player data. Player data from the import script is now all Pascel case in the database, matching what our tools will do.